### PR TITLE
Issue #3 Use react-native.config.js instead of rnpm section

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,11 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
     buildToolsVersion "27.0.3"
     defaultConfig {
         minSdkVersion 16

--- a/package.json
+++ b/package.json
@@ -28,10 +28,5 @@
     "moment": ">=2.0.0",
     "prop-types": "*",
     "react-native": ">=0.45.0"
-  },
-  "rnpm": {
-    "android": {
-      "packageInstance": "new ReactNativeWheelPickerPackage()"
-    }
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance: "new ReactNativeWheelPickerPackage()"
+      }
+    }
+  }
+};


### PR DESCRIPTION
"rnpm" is deprecated and support for it will be removed in next major version of the CLI.
https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide
Solves #3 