### PR TITLE
Issue #3 Use react-native.config.js instead of rnpm section

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,5 @@
     "moment": ">=2.0.0",
     "prop-types": "*",
     "react-native": ">=0.45.0"
-  },
-  "rnpm": {
-    "android": {
-      "packageInstance": "new ReactNativeWheelPickerPackage()"
-    }
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance: "new ReactNativeWheelPickerPackage()"
+      }
+    }
+  }
+};


### PR DESCRIPTION
"rnpm" is deprecated and support for it will be removed in next major version of the CLI.
https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide
Solves #3