### PR TITLE
#7 Add safeExtGet to get sdk version from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,11 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
     buildToolsVersion "27.0.3"
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Compile with the SDK version of the root project if available.
Solves #7