### PR TITLE
Selected value is always based on props

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -37,7 +37,6 @@ export default class Picker extends Component {
   };
 
   handleChange = (selectedValue) => {
-    this.setState({ selectedValue });
     this.props.onValueChange(selectedValue);
   };
 

--- a/src/picker.js
+++ b/src/picker.js
@@ -36,10 +36,6 @@ export default class Picker extends Component {
     selectedValue: '',
   };
 
-  state = {
-    selectedValue: this.props.selectedValue,
-  };
-
   handleChange = (selectedValue) => {
     this.setState({ selectedValue });
     this.props.onValueChange(selectedValue);
@@ -80,7 +76,7 @@ export default class Picker extends Component {
       <WheelCurvedPicker
         {...props}
         style={[styles.picker, style]}
-        selectedValue={this.state.selectedValue}
+        selectedValue={this.props.selectedValue}
         onValueChange={this.handleChange}
       >
         {pickerData.map((data, index) => (
@@ -95,6 +91,6 @@ export default class Picker extends Component {
   }
 
   getValue() {
-    return this.state.selectedValue;
+    return this.props.selectedValue;
   }
 }


### PR DESCRIPTION
By always using 'props.selectedValue' instead of storing it internally in the State, it opens up the opportunity to change the selected value from outside the component.
Very useful if you don't know the value at initial-render-time.