### PR TITLE
Add missing color option for iOS

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -88,6 +88,7 @@ export default class Picker extends Component {
             key={index}
             value={typeof data.value !== 'undefined' ? data.value : data.toString()}
             label={typeof data.label !== 'undefined' ? data.label : data.toString()}
+            color={this.props.textColor}
           />
         ))}
       </WheelCurvedPicker>


### PR DESCRIPTION
Changing color of the text was missing.

This PR will add the missing option.