### PR TITLE
add package name back to AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.tron"/>


### PR DESCRIPTION
Add package name back to `AndroidManifest.xml` that was removed in a commit on the 4th of June 2023.

https://github.com/TronNatthakorn/react-native-wheel-pick/commit/263fa97ab00062711617c02db447ee0ef37986df

Original credit to @ra30r and @JairajJangleSLIOT.

https://github.com/TronNatthakorn/react-native-wheel-pick/issues/39#issuecomment-1612179547

I know @TronNatthakorn has mentioned a few times that this library does not officially support expo, but it turns out the issue is fairly simple.

Without the package name, this happens:

```
➜  ios git:(develop) ✗ pod install
Using Expo modules
[Expo] Enabling modular headers for pod ExpoModulesCore
error Failed to build the app: No package name found. Found errors in /node_modules/react-native-wheel-pick/android/src/main/AndroidManifest.xml.

[!] Invalid `Podfile` file: 859: unexpected token at 'info Run CLI with --verbose flag for more details.
'.

 #  from /ios/Podfile:14
 #  -------------------------------------------
 #    use_expo_modules!
 >    config = use_native_modules!
 #  
 #  -------------------------------------------
```