### PR TITLE
Fix Android Timepicker SelectedValue + Support minuteInterval and maximumHours

### DIFF
--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -45,6 +45,8 @@ export default class DatePicker extends PureComponent {
     // style: ViewPropTypes.style,
     // textColor: ColorPropType,
     textSize: PropTypes.number,
+    minuteInterval: PropTypes.number,
+    maximumHours: PropTypes.number,
   };
 
   static defaultProps = {
@@ -61,12 +63,14 @@ export default class DatePicker extends PureComponent {
     style: null,
     textColor: '#333',
     textSize: 26,
+    minuteInterval: 1,
+    maximumHours: 24,
   };
 
   constructor(props) {
     super(props);
 
-    const { date, minimumDate, maximumDate, labelUnit } = props;
+    const { date, minimumDate, maximumDate, labelUnit, minuteInterval, maximumHours } = props;
 
     this.state = { date, monthRange: [], yearRange: [] };
 
@@ -240,11 +244,13 @@ export default class DatePicker extends PureComponent {
     const [hours, minutes] = [[], []];
 
     for (let i = 0; i <= 24; i += 1) {
-      hours.push(i);
+      if (i<=this.props.maximumHours)
+        hours.push(i);
     }
 
     for (let i = 0; i <= 59; i += 1) {
-      minutes.push(i);
+      if (i%this.props.minuteInterval === 0)
+        minutes.push(i);
     }
 
     return [

--- a/src/picker.js
+++ b/src/picker.js
@@ -80,7 +80,7 @@ export default class Picker extends Component {
       <WheelCurvedPicker
         {...props}
         style={[styles.picker, style]}
-        selectedValue={this.state.selectedValue}
+        selectedValue={this.state.selectedValue+""}
         onValueChange={this.handleChange}
       >
         {pickerData.map((data, index) => (


### PR DESCRIPTION
FIX on Android DatePicker in time mode date={} wasn't working. 
ADD support for minuteInterval on Android
ADD new option maximumHours on Android (since maximumDate does not work for time)