### PR TITLE
fix(android): add missing package name in AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.tron">
 </manifest>


### PR DESCRIPTION
This patch fixes a build failure caused by the absence of a `package` attribute in the AndroidManifest.xml. 
Some tools and the React Native CLI require this to correctly parse and configure native modules.

Tested locally by linking the library via a local path and running `./gradlew clean` successfully.
