### PR TITLE
Fix Android DatePicker time mode default selection issue and correct hour range

### DIFF
--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -239,12 +239,12 @@ export default class DatePicker extends PureComponent {
 
     const [hours, minutes] = [[], []];
 
-    for (let i = 0; i <= 24; i += 1) {
-      hours.push(i);
+    for (let i = 0; i <= 23; i += 1) {
+      hours.push({ value: i, label: `${i}` })
     }
 
     for (let i = 0; i <= 59; i += 1) {
-      minutes.push(i);
+      minutes.push({ value: i, label: `${i}` })
     }
 
     return [


### PR DESCRIPTION
This PR addresses an issue in the Android version of the `DatePicker` component when used in `time` mode.

### 🐞 Problem:
- When the `pickerData` passed to the internal `Picker` component is a numeric array, the default `selectedValue` (which is a number) does not match any picker item.
- This happens because the `Picker` component ([picker.js#L119](https://github.com/TronNatthakorn/react-native-wheel-pick/blob/master/src/picker.js#L119)) coerces non-object values to strings as `PickerItem` values.
- Therefore, a numeric `selectedValue` (like `12`) cannot match a stringified picker item value (`"12"`), and the Picker fails to select the correct default index.

### ✅ Fix:
- Converted the `hours` and `minutes` arrays into arrays of objects with the shape `{ value, label }`.
- This ensures that the `Picker` component uses the object’s `value` directly and doesn't perform unwanted type conversion.
- As a result, the correct index for the `selectedValue` is found and selected by default.

### 🔧 Minor Update:
- Changed the `hours` loop range from `0–24` to `0–23`.  
  The original implementation generated 25 hour options (0 to 24), but in a 24-hour format, `24` is not a valid hour and should be excluded.
