### PR TITLE
add support for isCyclic property on Android

### DIFF
--- a/android/src/main/java/com/tron/ReactWheelCurvedPickerManager.java
+++ b/android/src/main/java/com/tron/ReactWheelCurvedPickerManager.java
@@ -190,6 +190,14 @@ public class ReactWheelCurvedPickerManager extends SimpleViewManager<ReactWheelC
         }
     }
 
+   // @ReactProp(name="isCyclic")
+   @ReactProp(name="isCyclic")
+   public void setCyclic(ReactWheelCurvedPicker picker, boolean isCyclic) {
+       if (picker != null) {
+            picker.setCyclic(isCyclic);
+      }
+   }
+
     @Override
     public String getName() {
         return REACT_CLASS;


### PR DESCRIPTION
On iOS, the hour and minute pickers scroll infinitely. So if you're at minute 58 and want to set it to 0, you wouldn't want to scroll all the way back through 58 steps. The Android library already supports this behavior; I just added the corresponding property here.