### PR TITLE
Add support for decimal number support

### DIFF
--- a/android/src/main/java/com/tron/ReactWheelCurvedPicker.java
+++ b/android/src/main/java/com/tron/ReactWheelCurvedPicker.java
@@ -41,7 +41,7 @@ public class ReactWheelCurvedPicker extends WheelPicker {
     public ReactWheelCurvedPicker(ReactContext reactContext) {
         super(reactContext);
 
-        if(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {	
+        if(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {   
             mEventDispatcher = (UIManagerHelper.getUIManager(reactContext, 1 /** UIManagerType */)).getEventDispatcher();
         } else {
             mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -110,6 +110,8 @@ class ItemSelectedEvent extends Event<ItemSelectedEvent> {
         Class mValueClass = mValue.getClass();
         if (mValueClass == Integer.class) {
             eventData.putInt("data", (Integer) mValue);
+        } else if (mValueClass == Double.class) {
+            eventData.putDouble("data", (Double) mValue);
         } else if (mValueClass == String.class) {
             eventData.putString("data", mValue.toString());
         }

--- a/android/src/main/java/com/tron/ReactWheelCurvedPicker.java
+++ b/android/src/main/java/com/tron/ReactWheelCurvedPicker.java
@@ -41,7 +41,7 @@ public class ReactWheelCurvedPicker extends WheelPicker {
     public ReactWheelCurvedPicker(ReactContext reactContext) {
         super(reactContext);
 
-        if(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {   
+        if(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             mEventDispatcher = (UIManagerHelper.getUIManager(reactContext, 1 /** UIManagerType */)).getEventDispatcher();
         } else {
             mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();

--- a/android/src/main/java/com/tron/ReactWheelCurvedPickerManager.java
+++ b/android/src/main/java/com/tron/ReactWheelCurvedPickerManager.java
@@ -70,7 +70,8 @@ public class ReactWheelCurvedPickerManager extends SimpleViewManager<ReactWheelC
                 if (itemMap.getType("value") == ReadableType.String) {
                     valueData.add(itemMap.getString("value"));
                 } else if (itemMap.getType("value") == ReadableType.Number) {
-                    valueData.add(itemMap.getInt("value"));
+                    // Store as Double to preserve decimal precision
+                    valueData.add(itemMap.getDouble("value"));
                 }
 
                 labelData.add(itemMap.getString("label"));


### PR DESCRIPTION
Currently, the Android version of `react-native-wheel-pick` truncates decimal numbers to integers. When you pass a decimal value like 1.7, it gets converted to 1 and loses the decimal part.

## Updated
**ReactWheelCurvedPickerManager.java**
- Switched from `getInt()` to `getDouble()` so decimals are preserved
- Now all numbers are stored as `Double` objects

**ReactWheelCurvedPicker.java**  
- Added proper handling for `Double.class` when serializing values back to JS

## Result
Now decimal numbers work perfectly andIntegers still work fine too, so no breaking changes.